### PR TITLE
Only add the maven entry once.

### DIFF
--- a/plugins/notifee-mod.js
+++ b/plugins/notifee-mod.js
@@ -3,12 +3,14 @@ const { withProjectBuildGradle } = require('expo/config-plugins')
 module.exports = function withNotifeeRepo(config) {
   return withProjectBuildGradle(config, async config => {
     const contents = config.modResults.contents
-    const replacement = `maven { url 'https://www.jitpack.io' }
-        maven {
-            url "$rootDir/../node_modules/@notifee/react-native/android/libs" 
-        }`
 
-    config.modResults.contents = contents.replace("maven { url 'https://www.jitpack.io' }", replacement)
+    if (!contents.includes('@notifee/react-native')) {
+      const replacement = `maven { url 'https://www.jitpack.io' }
+        maven {
+            url "$rootDir/../node_modules/@notifee/react-native/android/libs"
+        }`
+      config.modResults.contents = contents.replace("maven { url 'https://www.jitpack.io' }", replacement)
+    }
 
     return config
   })


### PR DESCRIPTION
Running `expo prebuild` multiple times adds the maven entry each run.